### PR TITLE
Change createBrowserRouter to createHashRouter

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,9 +1,9 @@
-import {createBrowserRouter,Outlet} from "react-router-dom"
+import {createHashRouter,Outlet} from "react-router-dom"
 import PageNotFound from "./pages/page404"
 import Play from "./pages/play"
 import MainPage from "./pages"
 
-const router = createBrowserRouter([{
+const router = createHashRouter([{
     path:"/",
     element:<Outlet/>,
     errorElement:<PageNotFound/>,


### PR DESCRIPTION
Changing `createBrowserRouter` to `createHashRouter` to be able to restart the page that is live and not result in a page not found