### PR TITLE
Fix "super jump", delay collision and wrong pause position

### DIFF
--- a/src/css/bestScore.css
+++ b/src/css/bestScore.css
@@ -5,8 +5,6 @@
     font-weight: 600;
 
     font-family: 'Jockey One', sans-serif;
-
-    flex: 1;
 }
 
 @media only screen and (min-width: 1100px) and (max-width: 1600px) {

--- a/src/css/mainScore.css
+++ b/src/css/mainScore.css
@@ -3,6 +3,7 @@
     display: flex;
 
     flex-direction: row;
+    justify-content: space-between;
 
     width: 100%;
     height: 8%;

--- a/src/css/pauseOrResume.css
+++ b/src/css/pauseOrResume.css
@@ -4,16 +4,11 @@
 }
 
 #buttonResume {
-    flex: 1;
-
     background: transparent;
     border: none;
 }
 
 #pause {
-    top: -0.3%;
-    left: 39%;
-
     font-size: 25px;
     font-weight: bolder;
 
@@ -21,12 +16,7 @@
 }
 
 @media only screen and (min-width: 1100px) and (max-width: 1600px) {
-    #buttonResume {
-        left: 48%
-    }
-
     #pause {
-        left: 46%;
         font-size: 30px;
     }
 }

--- a/src/css/score.css
+++ b/src/css/score.css
@@ -1,9 +1,6 @@
 #score {
     position: relative;
-
     
-    flex: 1;
-
     color: black;
 
     font-weight: 700;
@@ -13,7 +10,6 @@
 
 @media only screen and (min-width: 1100px) and (max-width: 1600px) {
     #score {
-        left: 85%;
         font-size: 1.4rem;
     }
 }

--- a/src/elements/distance.ts
+++ b/src/elements/distance.ts
@@ -1,37 +1,19 @@
 import { itemObstacle } from "../globalContext/childsObstacle"
-import topAddition from "./topAdd"
 
 interface Distance {
-    player:{
-        x:number,
-        y:number
-    },
+    playerX: number,
     obstacle:itemObstacle,
-    size: {
-        width: number,
-        height: number
-    }
-}
-
-interface Position {
-    x:number,
-    y:number
 }
 
 type distance = Distance
 
 /** get distance between player and obstacle*/
 const getDistance = (area:distance) => {
-    let defaultPositionY = topAddition({size:area.size,to:"player"})
-    let positionDistance:Position = {
-        x:0,
-        y:0
-    }
+    let positionX = 0
 
-    positionDistance.x = area.player.x - area.obstacle.move
-    positionDistance.y = defaultPositionY - area.player.y
+    positionX = area.playerX - area.obstacle.move
 
-    return positionDistance
+    return positionX
 }
 
 export default getDistance

--- a/src/elements/user/player.tsx
+++ b/src/elements/user/player.tsx
@@ -25,6 +25,7 @@ const Player = () => {
 	let [active, setActive] = useState<string>("")
 	let [position, setPosition] = useState(defaultPosition)
 	let [spriteNumber, setSpriteNumber] = useState<number>(0)
+	let [isJumping,setIsJumping] = useState<boolean>(false)
 
 	useEffect(() => {
 		if (typeof press.event === "boolean" &&
@@ -45,7 +46,9 @@ const Player = () => {
 
 		let jumpP = () => {
 			if (!press.event) return;
-			let defaultS: number = 45
+			let defaultS: number = 15
+
+			setIsJumping(true)
 
 			let fase1 = setTimeout(() => {
 				if (active == "") {
@@ -68,6 +71,7 @@ const Player = () => {
 					setSpriteNumber(1)
 					setPosition(defaultPosition)
 					press.setEvent(false)
+					setIsJumping(false)
 					return;
 				}
 			}, 65)
@@ -97,17 +101,13 @@ const Player = () => {
 
 			obstacle.item.map((obst) => {
 				let distance = getDistance({
-					size: size,
 					obstacle: obst,
-					player: {
-						x: 13,
-						y: position
-					}
+					playerX: 13
 				})
 
-				if (distance.x >= -obst.size.width && 
-					distance.x <= 0 && 
-					(-1 * distance.y) <= obst.size.height - 11) {
+				if (distance >= -27 &&
+					distance <= 30&& 
+					!isJumping) {
 					fallenP()
 					gameover.setActive(true)
 				}


### PR DESCRIPTION
The jumper was jumping higher than expected. Solved by reducing the jump size. 

The player's collision with the obstacle didn't take long to be detected. Solved by removing the distance between them by the "y" position (previous detector) for a "boolean" variable that detects whether the player jumps or not, reducing the calculation consumption for the computer and making the collision faster.

The position of pause when clicked was "thrown" to the bottom right corner. Solved by removing the "flex" property in the children of the div tag, and adding the "justify-content" property to the parent tag with the value "space-between" to leave the right and left children in the corners and the middle one centered.