### PR TITLE
Change obstacle's speed and player's animation

### DIFF
--- a/src/elements/challenge/obstacle.tsx
+++ b/src/elements/challenge/obstacle.tsx
@@ -21,7 +21,7 @@ const Obstacle = () => {
 	let device = useDeviceSize()
 	let permision = usePermision()
 	let [Render, setRender] = useState<any>()
-	let [speedMove, setSpeedMove] = useState<number>(5)
+	let [speedMove, setSpeedMove] = useState<number>(9)
 	const obstacleNames = [
 		findObstacleImgs({ name: "traffic cone" }),
 		findObstacleImgs({ name: "rock" }),
@@ -45,9 +45,9 @@ const Obstacle = () => {
 			})
 		}
 
-		if (score.pits % 10 == 0 && speedMove != speedLimit) setSpeedMove(++speedMove)
+		if (score.pits % 10 == 0 && speedMove != speedLimit) setSpeedMove(speedMove += 0.1)
 		
-		const create = () => {
+			const create = () => {
 			if (!permision.create) return
 
 			let index = obstacleNames.length - obstacleLimit
@@ -62,10 +62,11 @@ const Obstacle = () => {
 					sourcePath: name,
 					key: identification,
 					move: device.size.width,
+					speed: speedMove,
 					size: { height: size.height, width: size.width },
 					setMove: () => { },
 					setSize: () => { }
-				}
+				},
 			] as itemObstacle[])
 
 			permision.setCreate(false)
@@ -75,7 +76,7 @@ const Obstacle = () => {
 			if (obstacle.item.length == 0) return
 
 			obstacle.item.map((obj) => {
-				obj.setMove(obj.move -= speedMove)
+				obj.setMove(obj.move -= obj.speed)
 
 				if (obj.move <= -110) remove(obj.key)
 			})

--- a/src/elements/user/player.tsx
+++ b/src/elements/user/player.tsx
@@ -46,10 +46,10 @@ const Player = () => {
 
 		let jumpP = () => {
 			if (!press.event) return;
-			let defaultS: number = 15
+			let defaultS: number = 20
 
 			setIsJumping(true)
-
+			
 			let fase1 = setTimeout(() => {
 				if (active == "") {
 					setSpriteNumber(5)
@@ -74,7 +74,7 @@ const Player = () => {
 					setIsJumping(false)
 					return;
 				}
-			}, 65)
+			}, 60)
 
 			return () => clearTimeout(fase1)
 		}
@@ -85,7 +85,7 @@ const Player = () => {
 			let fase = setTimeout(() => {
 				if (spriteNumber === 0 || spriteNumber == 2) return setSpriteNumber(1)
 				if (spriteNumber === 1) return setSpriteNumber(2)
-			}, 150)
+			}, 90)
 
 			return () => clearTimeout(fase)
 		}

--- a/src/globalContext/childsObstacle.ts
+++ b/src/globalContext/childsObstacle.ts
@@ -10,6 +10,7 @@ interface ItemObstacle {
     move:number,
     sourcePath:string,
     size:ObstacleSize,
+    speed:number,
     setSize:(obstacleSize:ObstacleSize) => void
     setMove:(value:number) => void
 }


### PR DESCRIPTION
Increasing the speed of the player's animation to give a racing effect. 

Increasing the character's jump a little to "20".

The speed of the obstacles was shared, which gave the impression that he was teleporting or that a collision was happening without the player being able to see.

Adding a property to `childsObstacle`, to "speed". The new property added was with the purpose of maintaining a constant speed for each obstacle created.

