### PR TITLE
Remove permision to translate the pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Air girl</title>
+    <title translate="no">Air girl</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Joti+One&display=swap" rel="stylesheet">

--- a/src/elements/bestScore/highScore.tsx
+++ b/src/elements/bestScore/highScore.tsx
@@ -28,7 +28,8 @@ const BestScore = () => {
 
 	return (<>
 		<p
-			id="bestScore">
+			id="bestScore"
+			translate="no">
 			bestScore: {record.value}
 		</p>
 	</>)

--- a/src/elements/pause/halt.tsx
+++ b/src/elements/pause/halt.tsx
@@ -33,6 +33,7 @@ const Halt = () => {
 			<p
 				id="pause"
 				onClick={() => {return pause.setActive(false)}}
+				translate="no"
 			>
 				Pause
 			</p>

--- a/src/elements/reset/gameOver.tsx
+++ b/src/elements/reset/gameOver.tsx
@@ -79,7 +79,8 @@ const GameOver = () => {
 				boxShadow: "2px 4px 3px black",
 				transition: "all 100ms",
 				background: backgroundColor
-			}}>
+			}}
+			translate="no">
 			Try again
 		</button>
 	</>)

--- a/src/elements/time/score.tsx
+++ b/src/elements/time/score.tsx
@@ -35,7 +35,7 @@ const Score = () => {
     }, [score.pits,pause.active])
 
     return (<>
-        <p id="score">Score: {
+        <p id="score" translate="no">Score: {
             score.pits
         }</p>
     </>)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,10 +15,10 @@ const MainPage = () => {
             <div className="Item"></div>
         </div>
 
-        <h1 id="title">Air <br/> girl</h1>
+        <h1 id="title" translate="no">Air <br/> girl</h1>
 
         <Link to={"/playing"}>
-            <button id="mainButton">Play</button>
+            <button id="mainButton" translate="no">Play</button>
         </Link>
     </div>)
 }


### PR DESCRIPTION
The "translate" attribute was applied to the components and tags because the translation made by the browser "broke" the classification count, meaning the points no longer counted. Therefore, I decided to remove the "forcing" translation on the site.

The reason it is applied to the other components (apart from the scoring component) is to maintain an aesthetic style in the game.

It was just not applied on the error page, because, due to this error, I wanted the player to report what happened.